### PR TITLE
Bug fix: Phase.add_endmember_properties()

### DIFF
--- a/src/pytheriak/wrapper.py
+++ b/src/pytheriak/wrapper.py
@@ -606,7 +606,7 @@ class Phase:
         for line in lines:
             endmember_name = line[0]
             activity = float(line[-2])
-            fraction = float(line[-4])
+            fraction = float(line[-3])
 
             endmember_activities[endmember_name] = activity
             endmember_fractions[endmember_name] = fraction


### PR DESCRIPTION
read second and not fist column for endmember fraction of solution phases. Some database add additional "00" in front of the first column for certain EM.

See also issueValueError in Phase.add_endmember_properties() #6